### PR TITLE
repo for gem install xmlparser failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-slim
+FROM ubuntu:16.04
 
 # some basic stuff
 RUN mkdir /usr/src/app

--- a/app/install_packages.sh
+++ b/app/install_packages.sh
@@ -6,12 +6,14 @@ if [ -z ${PACKAGES} ]; then
 else
   echo 'installing packages'
   apt-get update
+  apt-get install -y ruby2.3 ruby2.3-dev
   IFS=',' read -ra INSTALL_PACKAGES <<< $PACKAGES
   for i in "${INSTALL_PACKAGES[@]}"; do
     echo $i
     apt-get install -y $i
   done
   echo 'installing Gems'
+  gem install bundle
   bundle install
   echo 'listing installed packages:'
   dpkg --get-selections


### PR DESCRIPTION
It looks like the `ruby2.3-dev` package is the curlpit. I couldn't get the repro working with the `2.3-slim` image so changed it to `ubuntu:16.04`.